### PR TITLE
buildが通るかチェックするGitHub actionsの作成

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,10 +4,9 @@ on:
   pull_request:
     branches:
       - main
-      - develop
 
 jobs:
-  lint:
+  build:
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
# 概要

本番公開前にbuildが通らないのとだめなので確認できるように

## やったこと

- yarn buildを実行するgithub actionの作成(fa10d82145b4bc853b4e449ea4e2b8536d2e5b53)

## 補足

- 本当は`main`にPRを出した時のみ動いてほしいが、動作確認のため`develop`を含めてこのPRを作成する
