### PR TITLE
都道府県から総人口のグラフを表示するページの作成

### DIFF
--- a/src/pages/content.tsx
+++ b/src/pages/content.tsx
@@ -1,3 +1,79 @@
+import { LineChart } from '@src/component/Chart/LineChart/LineChart'
+import { fetchTotalPopulation } from '@src/feature/population/getTotalPopulation/getTotalPopulation'
+import { PrefectureCheckboxGroup } from '@src/feature/prefecture/PrefectureCheckboxGroup/PrefectureCheckboxGroup'
+import type { TotalPopulation } from '@src/model/population/totalPopulation'
+import { useMemo, useState } from 'react'
+import { isArrayNotEmpty } from 'typesafe-utils'
+
 export const Content = () => {
-  return <div>Next.js</div>
+  const [state, setState] = useState<
+    Map<
+      string,
+      {
+        name: string
+        data: TotalPopulation[]
+      }
+    >
+  >(new Map())
+
+  const minYear = useMemo(() => {
+    const years = Array.from(state).flatMap(([, value]) =>
+      value.data.map((v) => v.year)
+    )
+    return isArrayNotEmpty(years) ? Math.min(...years) : 0
+  }, [state])
+
+  const lineChartData = Array.from(state).map(([, value]) => ({
+    name: value.name,
+    values: value.data.map((data) => data.value),
+  }))
+
+  const setTotalPopulation = async (prefecture: {
+    name: string
+    code: number
+  }) => {
+    const data = await fetchTotalPopulation({
+      prefectureCode: prefecture.code,
+    })
+    setState((prevState) => {
+      const newState = new Map(prevState)
+      newState.set(prefecture.name, {
+        data,
+        name: prefecture.name,
+      })
+      return newState
+    })
+  }
+
+  const deleteTotalPopulation = (prefecture: {
+    name: string
+    code: number
+  }) => {
+    setState((prevState) => {
+      const newState = new Map(prevState)
+      newState.delete(prefecture.name)
+      return newState
+    })
+  }
+
+  const handleChangeCheckbox = async ({
+    isChecked,
+    prefecture,
+  }: {
+    isChecked: boolean
+    prefecture: { name: string; code: number }
+  }) => {
+    if (isChecked) {
+      await setTotalPopulation(prefecture)
+    } else {
+      deleteTotalPopulation(prefecture)
+    }
+  }
+
+  return (
+    <div>
+      <PrefectureCheckboxGroup onChange={handleChangeCheckbox} />
+      <LineChart title={'総人口'} data={lineChartData} pointStart={minYear} />
+    </div>
+  )
 }


### PR DESCRIPTION
# 概要

都道府県一覧を取得しcheckboxをレンダリングして選択された都道府県の総人口の折れ線グラフを表示する

## やったこと

- これまでのcomponentとhooksを組み合わせて都道府県の総人口を表示する折れ線グラフを表示するページの作成(8970913481c34077d890a9b51b70ad65d0f68c99)

## UI

<img width="2056" alt="CleanShot 2022-12-22 at 04 41 30@2x" src="https://user-images.githubusercontent.com/56404715/208989669-4c6e9cd6-b34b-4d57-a8f6-5518ee9a77e5.png">
<img src="https://user-images.githubusercontent.com/56404715/208990324-14c4b117-4968-4229-9ea8-5c4225ff7f2c.gif" />