### PR TITLE
LineChartのレスポンシブが動かない場合の修正

### DIFF
--- a/src/component/Chart/LineChart/LineChart.tsx
+++ b/src/component/Chart/LineChart/LineChart.tsx
@@ -81,7 +81,7 @@ export const LineChart = ({ data, pointStart, title, xAxis, yAxis }: Props) => {
     }
   }, [data, pointStart, title, xAxis?.title, yAxis?.title])
 
-  const [windowWidth, setWindowWidth] = useState(0)
+  const [documentWidth, setDocumentWidth] = useState(0)
 
   /**
    * sizeが大きくなる時は、グラフのサイズが変わるが小さくなる場合はみ出すのでwindowのサイズに応じて再描画させる
@@ -89,11 +89,11 @@ export const LineChart = ({ data, pointStart, title, xAxis, yAxis }: Props) => {
   useEffect(() => {
     if (typeof window !== 'undefined') {
       const handleResize = () => {
-        const width = window.innerWidth
+        const width = document.documentElement.clientWidth
         if (width >= 900) {
           return
         }
-        setWindowWidth(width)
+        setDocumentWidth(width)
       }
 
       window.addEventListener('resize', handleResize)
@@ -103,9 +103,10 @@ export const LineChart = ({ data, pointStart, title, xAxis, yAxis }: Props) => {
       return
     }
   }, [])
+
   return (
     <HighchartsReact
-      key={`LineChart_${windowWidth}`}
+      key={`LineChart_${documentWidth}`}
       highcharts={Highcharts}
       options={options}
     />


### PR DESCRIPTION
# 概要

windowがリサイズされない場合に正しくレスポンシブされていなかったのでhtml要素からwidthを取得するように変更

## やったこと

- window.innerWidthだと正しく動かない場合があったためhtmlのwidthを取得すように変更(2c8e2706c546da1f6f9c95a2c20c48fc518b7bcc)

## UI

<table>
  <tr>
    <th>before</th>
    <th>after</th>
  </tr>
  <tr>
    <td colspan="2">トップページ</td>
  </tr>
  <tr>
    <td>
<img src="https://user-images.githubusercontent.com/56404715/208993174-48d296b2-de5c-476e-b18c-bf4acd37a280.gif" />
<img src="https://user-images.githubusercontent.com/56404715/208993550-cbebee8b-e6e3-4315-a64d-24b730c35ee9.gif" />
</td>
    <td>
<img src="https://user-images.githubusercontent.com/56404715/208993186-c58b0e12-9b08-403a-adfb-fc08e4041aca.gif" />
<img src="https://user-images.githubusercontent.com/56404715/208993195-de36e0b4-0dd6-4256-a42b-18a70e26f77f.gif" />
</td>
  </tr>
</table>
