### PR TITLE
.env.exampleのRESAS_API_URLの/apiが不要なので削除した

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,5 @@
 NEXT_PUBLIC_FRONTEND_URL=http://localhost:3000
 RESAS_API_KEY=resasで取得したAPIキー
-RESAS_API_URL=https://opendata.resas-portal.go.jp/api
+RESAS_API_URL=https://opendata.resas-portal.go.jp
 NEXT_PUBLIC_DESCRIPTION=都道府県別の総人口推移を可視化するサイトです。
 NEXT_PUBLIC_TITLE=都道府県別の総人口推移グラフ


### PR DESCRIPTION
# 概要

.env.exampleのRESAS_API_URLの/apiが不要なので削除した
